### PR TITLE
chore: add .editorconfig file for consistent formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+
+[*.md]
+indent_style = space
+indent_size = 4
+# Maximum line length for code blocks (text lines are limited to 80 characters)
+max_line_length = 120
+trim_trailing_whitespace = true


### PR DESCRIPTION
## Motivation

Add [.editorconfig](https://editorconfig.org/) with configurations for maintaining a consistent text style

## Summary

- UTF-8 encoding and LF line endings for all files
- 4-space indentation for markdown files
- 120-character line length limit for code blocks in markdown
- Automatic trailing whitespace removal

## Related Changes

None

## Testing

Not required