### PR TITLE
fix: use jsonpath paths in OpenSLO validation rules

### DIFF
--- a/pkg/openslotonobl9/convert_test.go
+++ b/pkg/openslotonobl9/convert_test.go
@@ -90,7 +90,7 @@ func TestConvert_Validate(t *testing.T) {
 			)},
 			errors: []govytest.ExpectedRuleError{
 				{
-					PropertyPath: "['spec.target']",
+					PropertyPath: "spec.target",
 					Code:         rules.ErrorCodeOneOf,
 					Message:      "must be one of: discord, email, jira, msteams, opsgenie, pagerduty, servicenow, slack, webhook",
 				},
@@ -121,7 +121,7 @@ func TestConvert_Validate(t *testing.T) {
 			)},
 			errors: []govytest.ExpectedRuleError{
 				{
-					PropertyPath:    "['spec.type']",
+					PropertyPath:    "spec.type",
 					Code:            rules.ErrorCodeOneOf,
 					ContainsMessage: "must be one of: prometheus, datadog",
 				},
@@ -140,7 +140,7 @@ func TestConvert_Validate(t *testing.T) {
 			)},
 			errors: []govytest.ExpectedRuleError{
 				{
-					PropertyPath:    "['spec.type']",
+					PropertyPath:    "spec.type",
 					Code:            rules.ErrorCodeOneOf,
 					ContainsMessage: "must be one of: prometheus, datadog",
 				},
@@ -159,7 +159,7 @@ func TestConvert_Validate(t *testing.T) {
 			)},
 			errors: []govytest.ExpectedRuleError{
 				{
-					PropertyPath:    "['spec.type']",
+					PropertyPath:    "spec.type",
 					Code:            rules.ErrorCodeOneOf,
 					ContainsMessage: "must be one of: datadog, newRelic",
 				},
@@ -272,21 +272,21 @@ func TestConvert_Validate(t *testing.T) {
 			)},
 			errors: []govytest.ExpectedRuleError{
 				{
-					PropertyPath:    "['spec.indicator'].spec.ratioMetric.total.metricSource.type",
+					PropertyPath:    "spec.indicator.spec.ratioMetric.total.metricSource.type",
 					Code:            rules.ErrorCodeOneOf,
 					ContainsMessage: "must be one of: prometheus, datadog",
 				},
 				{
-					PropertyPath:    "['spec.indicator'].spec.ratioMetric.good.metricSource.type",
+					PropertyPath:    "spec.indicator.spec.ratioMetric.good.metricSource.type",
 					Code:            rules.ErrorCodeOneOf,
 					ContainsMessage: "must be one of: prometheus, datadog",
 				},
 				{
-					PropertyPath: "['spec.indicator'].spec.ratioMetric.total.metricSource.metricSourceRef",
+					PropertyPath: "spec.indicator.spec.ratioMetric.total.metricSource.metricSourceRef",
 					Code:         rules.ErrorCodeRequired,
 				},
 				{
-					PropertyPath: "['spec.indicator'].spec.ratioMetric.good.metricSource.metricSourceRef",
+					PropertyPath: "spec.indicator.spec.ratioMetric.good.metricSource.metricSourceRef",
 					Code:         rules.ErrorCodeRequired,
 				},
 			},

--- a/pkg/openslotonobl9/validation_rules.go
+++ b/pkg/openslotonobl9/validation_rules.go
@@ -10,6 +10,7 @@ import (
 	"github.com/OpenSLO/go-sdk/pkg/openslo"
 	v1 "github.com/OpenSLO/go-sdk/pkg/openslo/v1"
 	"github.com/nobl9/govy/pkg/govy"
+	"github.com/nobl9/govy/pkg/jsonpath"
 	"github.com/nobl9/govy/pkg/rules"
 	"github.com/nobl9/nobl9-go/manifest"
 	"github.com/nobl9/nobl9-go/manifest/v1alpha/agent"
@@ -46,7 +47,7 @@ var opensloV1Validation = govy.New(
 		When(whenObjectIsKind(openslo.KindAlertNotificationTarget)).
 		Include(govy.New(
 			govy.For(func(a v1.AlertNotificationTarget) string { return a.Spec.Target }).
-				WithName("spec.target").
+				WithPath(jsonpath.Parse("spec.target")).
 				Rules(rules.OneOf(slices.Sorted(maps.Keys(getAlertMethodTypes()))...)),
 		)),
 	govy.Transform(govy.GetSelf[openslo.Object](), objectTransformer[v1.AlertPolicy]).
@@ -72,7 +73,7 @@ var opensloV1AnnotationsValidation = govy.New(
 
 var opensloV1SLOValidation = govy.New(
 	govy.ForPointer(func(s v1.SLO) *v1.SLOIndicatorInline { return s.Spec.Indicator }).
-		WithName("spec.indicator").
+		WithPath(jsonpath.Parse("spec.indicator")).
 		Include(govy.New(
 			govy.For(func(s v1.SLOIndicatorInline) v1.SLISpec { return s.Spec }).
 				WithName("spec").
@@ -115,7 +116,7 @@ var opensloV1SLIMetricSpecValidation = govy.New(
 
 var opensloV1DataSourceValidation = govy.New(
 	govy.ForMap(func(d v1.DataSource) v1.Annotations { return d.Metadata.Annotations }).
-		WithName("spec.annotations").
+		WithPath(jsonpath.Parse("spec.annotations")).
 		RulesForKeys(rules.NEQ(DomainNobl9+"/apiVersion")).
 		IncludeForItems(govy.New(
 			govy.For(func(m govy.MapItem[string, string]) string { return m.Value }).
@@ -126,13 +127,13 @@ var opensloV1DataSourceValidation = govy.New(
 		When(func(d v1.DataSource) bool {
 			return hasAnnotation(d.Metadata.Annotations, DomainNobl9+"/kind", manifest.KindDirect.String())
 		}).
-		WithName("spec.type").
+		WithPath(jsonpath.Parse("spec.type")).
 		Rules(rules.OneOf(getDataSourceTypeNames(manifest.KindDirect)...)),
 	govy.For(func(d v1.DataSource) string { return d.Spec.Type }).
 		When(func(d v1.DataSource) bool {
 			return !hasAnnotation(d.Metadata.Annotations, DomainNobl9+"/kind", manifest.KindDirect.String())
 		}).
-		WithName("spec.type").
+		WithPath(jsonpath.Parse("spec.type")).
 		Rules(rules.OneOf(getDataSourceTypeNames(manifest.KindAgent)...)),
 )
 


### PR DESCRIPTION
Replace string field names with parsed JSONPath values for validation targets. This keeps validation errors aligned with the correct manifest field paths.