### PR TITLE
chore: support fork PR autolabeling and Go 1.26.4

### DIFF
--- a/.github/workflows/pr-autolabeler.yml
+++ b/.github/workflows/pr-autolabeler.yml
@@ -1,0 +1,19 @@
+name: PR Autolabeler
+
+on:
+  # pull_request_target is required to label PRs from forks.
+  # This workflow must stay metadata-only: do not checkout or run PR code here.
+  pull_request_target:
+    types: [opened, reopened, synchronize, edited]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  autolabeler:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter/autolabeler@v7
+        with:
+          token: ${{ github.token }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,28 +4,11 @@ on:
   push:
     branches:
       - main
-  # pull_request event is required only for autolabeler
-  # 'edited' event is required to account for initial invalid PR names
-  pull_request:
-    types: [opened, reopened, synchronize, edited]
-
 permissions:
   contents: read
 
 jobs:
-  autolabeler:
-    if: github.event_name == 'pull_request'
-    permissions:
-      # write permission is required to add labels to pull requests
-      pull-requests: write
-    runs-on: ubuntu-latest
-    steps:
-      - uses: release-drafter/release-drafter/autolabeler@v7
-        with:
-          token: ${{ github.token }}
-
   update_release_draft:
-    if: github.event_name == 'push'
     permissions:
       # write permission is required to create a github release
       contents: write

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nobl9/nobl9-openslo
 
-go 1.25.10
+go 1.26.4
 
 require (
 	github.com/OpenSLO/go-sdk v0.9.2


### PR DESCRIPTION
## Motivation

External contributor PRs cannot access repository secrets even after a maintainer approves workflow execution. The previous Release Drafter autolabeler job required a secret token on `pull_request`, so fork PRs failed before labels could be applied.

## Summary

- Moves PR autolabeling to a separate metadata-only `pull_request_target` workflow.
- Uses `github.token` with `pull-requests: write` instead of repository secrets for PR labeling.
- Keeps Release Drafter itself on the trusted `push` path.
- Bumps Go to 1.26.4 so `govulncheck` uses the fixed standard library.

## Related Changes

https://github.com/nobl9/nobl9-go/pull/937
